### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 tckfc
 =====
 
-[![Latest Version](https://pypip.in/version/tckfc/badge.svg)](https://pypi.python.org/pypi/tckfc/)
-[![Downloads](https://pypip.in/download/tckfc/badge.svg)](https://pypi.python.org/pypi/tckfc/)
-[![Download format](https://pypip.in/format/tckfc/badge.svg)](https://pypi.python.org/pypi/tckfc/)
-[![Supported Python versions](https://pypip.in/py_versions/tckfc/badge.svg)](https://pypi.python.org/pypi/tckfc/)
-[![License](https://pypip.in/license/tckfc/badge.svg)](https://pypi.python.org/pypi/tckfc/)
+[![Latest Version](https://img.shields.io/pypi/v/tckfc.svg)](https://pypi.python.org/pypi/tckfc/)
+[![Downloads](https://img.shields.io/pypi/dm/tckfc.svg)](https://pypi.python.org/pypi/tckfc/)
+[![Download format](https://img.shields.io/pypi/format/tckfc.svg)](https://pypi.python.org/pypi/tckfc/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/tckfc.svg)](https://pypi.python.org/pypi/tckfc/)
+[![License](https://img.shields.io/pypi/l/tckfc.svg)](https://pypi.python.org/pypi/tckfc/)
 
 This tool seeks asynchronously TrueCrypt key file using combinations of provided key files with provided password.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20tckfc))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `tckfc`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.